### PR TITLE
Choose a non-standard version of R for use with RStudio

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -42,5 +42,7 @@ attributes:
     label: "R version"
     help: "This defines the version of R you want to load."
     options:
+      # Define functioning R version overloads using a colon after the module load statement
+      - [ "3.5.0", "intel/16.0.3 R/3.4.2 rstudio/1.1.380_server:R/3.5.0"]
       - [ "3.4.2", "intel/16.0.3 R/3.4.2 rstudio/1.1.380_server"]
       - [ "3.3.2", "intel/16.0.3 R/3.3.2 rstudio/1.0.136_server"]

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 <%
-r_versions = context.version.split(':')
-modules_to_load = r_versions.first
-has_alternate_r_version = r_versions.size == 2
-alternate_r_version = has_alternate_r_version ? r_versions.last : ''
+modules_to_load, alternate_r_version = context.version.split(':')
 %>
 # Load the required environment
 setup_env () {
@@ -17,7 +14,7 @@ setup_env () {
   # Bonus points if you install the `example_module` on the system so you don't
   # need to run `module use`.
   module load <%= modules_to_load %>
-  <% if has_alternate_r_version %>
+  <% if alternate_r_version %>
   module switch <%= alternate_r_version %>
   export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
   <% end %>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-
+<%
+r_versions = context.version.split(':')
+modules_to_load = r_versions.first
+has_alternate_r_version = r_versions.size == 2
+alternate_r_version = has_alternate_r_version ? r_versions.last : ''
+%>
 # Load the required environment
 setup_env () {
   module purge
@@ -11,7 +16,11 @@ setup_env () {
   #
   # Bonus points if you install the `example_module` on the system so you don't
   # need to run `module use`.
-  module load <%= context.version %>
+  module load <%= modules_to_load %>
+  <% if has_alternate_r_version %>
+  module switch <%= alternate_r_version %>
+  export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
+  <% end %>
 }
 setup_env
 


### PR DESCRIPTION
Addresses #12.

By adding an optional delimited field to the `form.yml` value for `version` we can replace the loaded version of R at RStudio Server start time.

One issue that I had is that when I started up a 3.4.2 and 3.5.0 concurrently I had an error logging into the 3.5.0 instance. This only happened once and I have not been able to duplicate it, but it seems like there is some race condition in that particular workflow.