### PR TITLE
Singularity based RStudio

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -1,0 +1,21 @@
+Bootstrap: yum
+OSVersion: 7
+MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+Include: yum
+
+%labels
+  Maintainer OSC Gateways
+
+%help
+This will run RStudio Server which must be mounted with dependencies into the container
+
+%apprun rserver
+  export PATH="$USER_PATH"
+  exec rserver "${@}"
+
+%runscript
+  export PATH="$USER_PATH"
+  exec rserver "${@}"
+
+%post
+  yum install -y which

--- a/form.yml
+++ b/form.yml
@@ -44,6 +44,6 @@ attributes:
     help: "This defines the version of R you want to load."
     options:
       # Define functioning R version overloads using a colon after the module load statement
-      - [ "3.5.0", "intel/16.0.3 R/3.4.2 rstudio/1.1.380_server:R/3.5.0"]
+      - [ "3.5.0", "intel/16.0.3 R/3.5.0 rstudio/1.1.380_server"]
       - [ "3.4.2", "intel/16.0.3 R/3.4.2 rstudio/1.1.380_server"]
       - [ "3.3.2", "intel/16.0.3 R/3.3.2 rstudio/1.0.136_server"]

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -50,9 +50,9 @@ set -x
 # Launch the RStudio Server
 echo "Starting up rserver..."
 
-export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,/users,$TMPDIR:/tmp"
+export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,$TMPDIR:/tmp"
 
-singularity run /users/PZS0002/mrodgers/singularity/centos7.simg \
+singularity run /usr/local/project/ondemand/singularity/rstudio/rstudio_launcher_centos7.simg \
  --www-port "${port}" \
  --auth-none 0 \
  --auth-pam-helper-path "${RSTUDIO_AUTH}" \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -10,8 +10,6 @@ setup_env () {
   module switch <%= alternate_r_version %>
   export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
 <% end %>
-
-  module load singularity
 }
 setup_env
 
@@ -48,15 +46,11 @@ cd "${HOME}"
 # Output debug info
 module list
 
-# Create tmpdir rooted in PBSTMP
-# This will be bound into the guest and mounted at /tmp
-CONTAINER_TMP=$(mktemp -d)
-
 set -x
 # Launch the RStudio Server
 echo "Starting up rserver..."
 
-export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,/users,$CONTAINER_TMP:/tmp"
+export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,/users,$TMPDIR:/tmp"
 
 singularity run /users/PZS0002/mrodgers/singularity/centos7.simg \
  --www-port "${port}" \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -5,19 +5,13 @@ modules_to_load, alternate_r_version = context.version.split(':')
 # Load the required environment
 setup_env () {
   module purge
-  # If you want to use Singularity it is recommended you setup a module similar
-  # to the included `example_module` and load it as:
-  #
-  #     module use "/path/to/example_module/modulefiles"
-  #     module load singularity rstudio_singularity/3.4.3
-  #
-  # Bonus points if you install the `example_module` on the system so you don't
-  # need to run `module use`.
   module load <%= modules_to_load %>
-  <% if alternate_r_version %>
+<% if alternate_r_version %>
   module switch <%= alternate_r_version %>
   export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
-  <% end %>
+<% end %>
+
+  module load singularity
 }
 setup_env
 
@@ -37,6 +31,7 @@ sed 's/^ \{2\}//' > "${RSESSION_WRAPPER_FILE}" << EOL
 
   # Log all output from this script
   export RSESSION_LOG_FILE="${RSTUDIO_SINGULARITY_HOST_MNT}${PWD}/rsession.log"
+
   exec &>>"\${RSESSION_LOG_FILE}"
 
   # Launch the original command
@@ -47,24 +42,25 @@ EOL
 )
 chmod 700 "${RSESSION_WRAPPER_FILE}"
 
-# Define launcher for `rserver` if not using Singularity
-if [[ -z "${RSTUDIO_SINGULARITY_IMAGE}" ]]; then
-  PROOT_BIN="${PROOT_BIN:-"/usr/local/proot/bin/proot-x86_64"}"
-  RSERVER_LAUNCHER="${PROOT_BIN} -b $(mktemp -d):/tmp "
-fi
-
 # Set working directory to home directory
 cd "${HOME}"
 
 # Output debug info
 module list
 
+# Create tmpdir rooted in PBSTMP
+# This will be bound into the guest and mounted at /tmp
+CONTAINER_TMP=$(mktemp -d)
+
+set -x
 # Launch the RStudio Server
 echo "Starting up rserver..."
-set -x
-${RSERVER_LAUNCHER}rserver \
-  --www-port ${port} \
-  --auth-none 0 \
-  --auth-pam-helper-path "${RSTUDIO_SINGULARITY_HOST_MNT}${RSTUDIO_AUTH}" \
-  --auth-encrypt-password 0 \
-  --rsession-path "${RSTUDIO_SINGULARITY_HOST_MNT}${RSESSION_WRAPPER_FILE}"
+
+export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,/users,$CONTAINER_TMP:/tmp"
+
+singularity run /users/PZS0002/mrodgers/singularity/centos7.simg \
+ --www-port "${port}" \
+ --auth-none 0 \
+ --auth-pam-helper-path "${RSTUDIO_AUTH}" \
+ --auth-encrypt-password 0 \
+ --rsession-path "${RSESSION_WRAPPER_FILE}"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -4,8 +4,12 @@ modules_to_load, alternate_r_version = context.version.split(':')
 %>
 # Load the required environment
 setup_env () {
+  # Additional environment which could be moved into a module
+  export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,$TMPDIR:/tmp"
+  export RSTUDIO_SERVER_IMAGE="/usr/local/project/ondemand/singularity/rstudio/rstudio_launcher_centos7.simg"
+
   module purge
-  module load <%= modules_to_load %>
+  module load <%= modules_to_load %>  # rstudio_launcher
 <% if alternate_r_version %>
   module switch <%= alternate_r_version %>
   export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
@@ -50,9 +54,7 @@ set -x
 # Launch the RStudio Server
 echo "Starting up rserver..."
 
-export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,$TMPDIR:/tmp"
-
-singularity run /usr/local/project/ondemand/singularity/rstudio/rstudio_launcher_centos7.simg \
+singularity run "$RSTUDIO_SERVER_IMAGE" \
  --www-port "${port}" \
  --auth-none 0 \
  --auth-pam-helper-path "${RSTUDIO_AUTH}" \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-<%
-modules_to_load, alternate_r_version = context.version.split(':')
-%>
+
 # Load the required environment
 setup_env () {
   module purge
-  module use /users/PZS0002/mrodgers/.local/share/lmodfiles
-  module load <%= modules_to_load %> rserver-wrapper
-<% if alternate_r_version %>
-  module switch <%= alternate_r_version %>
-  export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
-<% end %>
+
+  # The rserver container module should set these environment variables:
+
+  #   SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64"
+  #   RSTUDIO_SERVER_IMAGE="/usr/local/project/ondemand/singularity/rstudio/rstudio_launcher_centos7.simg"
+  #   PATH="$PATH:/path/to/R:/path/to/rstudio/rserver"
+ 
+  # SINGULARITY_BINDPATH is being used to bind all RStudio's requirements from
+  # the host into the guest, and so those values may vary between sites.
+
+  module use /usr/local/share/lmodfiles/project/ondemand
+  module load <%= context.version %> rstudio_container/2019Feb
 }
 setup_env
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -4,12 +4,9 @@ modules_to_load, alternate_r_version = context.version.split(':')
 %>
 # Load the required environment
 setup_env () {
-  # Additional environment which could be moved into a module
-  export SINGULARITY_BINDPATH="/usr/local,/etc/profile.d/lmod.sh,/usr/share/lmod,/opt/intel,/opt/mvapich2,/usr/lib64,$TMPDIR:/tmp"
-  export RSTUDIO_SERVER_IMAGE="/usr/local/project/ondemand/singularity/rstudio/rstudio_launcher_centos7.simg"
-
   module purge
-  module load <%= modules_to_load %>  # rstudio_launcher
+  module use /users/PZS0002/mrodgers/.local/share/lmodfiles
+  module load <%= modules_to_load %> rserver-wrapper
 <% if alternate_r_version %>
   module switch <%= alternate_r_version %>
   export RSTUDIO_WHICH_R=/usr/local/<%= alternate_r_version %>
@@ -54,7 +51,7 @@ set -x
 # Launch the RStudio Server
 echo "Starting up rserver..."
 
-singularity run "$RSTUDIO_SERVER_IMAGE" \
+singularity run -B "$TMPDIR:/tmp" "$RSTUDIO_SERVER_IMAGE" \
  --www-port "${port}" \
  --auth-none 0 \
  --auth-pam-helper-path "${RSTUDIO_AUTH}" \


### PR DESCRIPTION
This commit removes the requirement for using `proot` to create private /tmp spaces. Instead a Singularity container is used which mounts RStudio and its dependencies from the host, plus overrides the mount for /tmp using a new tmp dir rooted in PBSTMP. The Singularity container is as simple as can be requiring only the installation of `which` over the base CentOS 7. Since R or RStudio are not installed in the image then the image should not require a rebuild in the event of changes to RStudio.

~~The path to the image is currently in my home directory, and needs to be moved to a system directory, or the WIAG user's home. Also naming the image something slightly more useful than `centos7.simg` like `rstudio_launcher_centos7.simg` may be useful.~~

Heechang has installed the image in a system directory.