### PR TITLE
EXAMPLE - Implementation of a hybrid vnc / basic RStudio

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -4,6 +4,7 @@ form:
   - version
   - bc_account
   - bc_num_hours
+  - rstudio_mode
   - node_type
   - num_cores
   - bc_email_on_started
@@ -22,6 +23,18 @@ attributes:
   bc_account:
     label: "Project"
     help: "You can leave this blank if **not** in multiple projects."
+  rstudio_mode:
+    widget: select
+    label: "RStudio Mode"
+    help: |
+      - **Desktop** - Run RStudio as a desktop application over VNC. This is best
+        for developing code that requires an X11 server for
+        visualizations.
+      - **Server** - Run RStudio Server. This is offers the best copy and paste
+        experience, but cannot be used to open X11 windows.
+    options:
+      - [ "Desktop", "desktop" ]
+      - [ "Server",  "server"  ]
   node_type:
     widget: select
     label: "Node type"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -6,10 +6,11 @@
           else
             ":ppn=#{ppn}"
           end
+  template = (rstudio_mode == "desktop") ? "vnc" : "basic"
 -%>
 ---
 batch_connect:
-  template: "basic"
+  template: "<%= template %>"
 script:
   <%- if node_type == "debug" -%>
   queue_name: "debug"

--- a/template/after.sh.erb
+++ b/template/after.sh.erb
@@ -1,3 +1,4 @@
+<% if (context.rstudio_mode == "server") %>
 # Wait for the RStudio Server to start
 echo "Waiting for RStudio Server to open port ${port}..."
 if wait_until_port_used "${host}:${port}" 120; then
@@ -7,3 +8,4 @@ else
   clean_up 1
 fi
 sleep 2
+<% end %>

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -1,9 +1,11 @@
 # Export the module function if it exists
 [[ $(type -t module) == "function" ]] && export -f module
 
+<% if (context.rstudio_mode == "server") %>
 # Find available port to run server on
 port=$(find_port ${host})
 
 # Define a password and export it for RStudio authentication
 password="$(create_passwd 16)"
 export RSTUDIO_PASSWORD="${password}"
+<% end %>

--- a/template/config/menus/xfce-applications.menu
+++ b/template/config/menus/xfce-applications.menu
@@ -1,0 +1,22 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN"
+  "http://www.freedesktop.org/standards/menu-spec/1.0/menu.dtd">
+
+<Menu>
+    <Name>Xfce</Name>
+
+    <DefaultAppDirs/>
+    <DefaultDirectoryDirs/>
+    <DefaultMergeDirs/>
+
+    <Include>
+        <All/>
+    </Include>
+
+    <Layout>
+        <Filename>firefox.desktop</Filename>
+        <Filename>xfce4-terminal.desktop</Filename>
+        <Filename>Thunar.desktop</Filename>
+        <Separator/>
+        <Filename>fluent-parallel.desktop</Filename>
+    </Layout>
+</Menu>

--- a/template/config/xfce4/terminal/terminalrc
+++ b/template/config/xfce4/terminal/terminalrc
@@ -1,0 +1,3 @@
+[Configuration]
+CommandLoginShell=TRUE
+FontName=DejaVu Sans Mono 11

--- a/template/config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/template/config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-panel" version="1.0">
+  <property name="configver" type="int" value="2"/>
+  <property name="panels" type="array">
+    <value type="int" value="1"/>
+    <property name="panel-1" type="empty">
+      <property name="position" type="string" value="p=6;x=99;y=24"/>
+      <property name="position-locked" type="bool" value="true"/>
+      <property name="size" type="uint" value="48"/>
+      <property name="length" type="uint" value="100"/>
+      <property name="length-adjust" type="bool" value="false"/>
+      <property name="plugin-ids" type="array">
+        <value type="int" value="1"/>
+        <value type="int" value="3"/>
+        <value type="int" value="8"/>
+        <value type="int" value="4"/>
+        <value type="int" value="5"/>
+      </property>
+      <property name="mode" type="uint" value="0"/>
+    </property>
+  </property>
+  <property name="plugins" type="empty">
+    <property name="plugin-3" type="string" value="tasklist">
+      <property name="flat-buttons" type="bool" value="false"/>
+      <property name="show-handle" type="bool" value="true"/>
+    </property>
+    <property name="plugin-4" type="string" value="pager"/>
+    <property name="plugin-5" type="string" value="clock">
+      <property name="digital-format" type="string" value="%r"/>
+      <property name="mode" type="uint" value="2"/>
+    </property>
+    <property name="plugin-8" type="string" value="separator">
+      <property name="expand" type="bool" value="true"/>
+      <property name="style" type="uint" value="2"/>
+    </property>
+    <property name="plugin-1" type="string" value="applicationsmenu">
+      <property name="show-generic-names" type="bool" value="true"/>
+      <property name="show-menu-icons" type="bool" value="true"/>
+      <property name="button-icon" type="string" value="fedora-logo-icon"/>
+      <property name="show-tooltips" type="bool" value="true"/>
+    </property>
+  </property>
+</channel>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # Load the required environment
 setup_env () {
   module purge
@@ -18,6 +17,7 @@ setup_env () {
 }
 setup_env
 
+<% if (context.rstudio_mode == "server") %>
 #
 # Start RStudio Server
 #
@@ -61,3 +61,37 @@ singularity run -B "$TMPDIR:/tmp" "$RSTUDIO_SERVER_IMAGE" \
  --auth-pam-helper-path "${RSTUDIO_AUTH}" \
  --auth-encrypt-password 0 \
  --rsession-path "${RSESSION_WRAPPER_FILE}"
+
+<% else %>
+#
+# Start RStudio Desktop
+# 
+# RStudio Desktop does not need to be 'chrooted' using Singularity
+#
+
+# Set working directory to home directory
+cd "${HOME}"
+
+#
+# Launch Xfce Window Manager and Panel
+#
+(
+  export XDG_CONFIG_HOME="<%= session.staged_root.join("config") %>"
+  export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
+  export XDG_CACHE_HOME="$(mktemp -d)"
+  xfwm4 --compositor=off --daemon --sm-client-disable
+  xsetroot -solid "#D3D3D3"
+  xfsettingsd --sm-client-disable
+  xfce4-panel --sm-client-disable
+) &
+
+#
+# Start RStudio
+#
+export PATH="$PATH:/users/PZS0002/mrodgers/rstudio-1.1.463/bin"
+
+rstudio
+
+<% end %>
+
+echo 'Fin'


### PR DESCRIPTION
A user requested the ability to be able to open X11 windows from their RStudio session. In order to support this request it is necessary to switch from RStudio Server to the desktop version of the application, running within a full desktop environment. This commit offers the user the ability at batch-submit-time to select whether they want RStudio Desktop or Server. Pleasingly RStudio Desktop respects the `TMPDIR` setting, and so does not need to be contained within a Singularity 'chroot'. Unfortunately because of the copy and paste limitations of our VNC implementation there is a significant difference in the user experience between the two modes, preventing RStudio desktop from being a clear favorite.

After consultation with @summerwang it was decided that this implementation is not required, as users may alternatively work from a regular BatchConnect desktop session.

In order to offer a BatchConnect application that can run in 'basic' or 'vnc' modes, where the 'basic' mode requires a custom launch button (`view.html.erb`), it was necessary to change the `batchconnect/session/panel` view in the Dashboard. If support for dual mode BatchConnect applications is desired in the future it would be advisable to revisit the template selection logic.