### PR TITLE
Fix for environment not being properly exported to rsession wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.8.8] - 2019-12-20
+### Fixed
+- Fix breaking changes with the way Singularity 3.5.x handles environment variables
+
 ## [0.8.7] - 2019-12-17
 ### Fixed
 - Fixed bug which prevented running simultaneous tutorial sessions
@@ -126,7 +130,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release!
 
-[Unreleased]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.8.7...HEAD
+[Unreleased]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.8.8...HEAD
+[0.8.8]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.8.4...v0.8.5

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -80,7 +80,7 @@ echo "Starting up rserver..."
 # /dev and /proc
 # optional_tutorial_home_bind is used when include_tutorials to change the home
 # directory to get a clean environment without clobbering files
-singularity run --contain -B "$TMPDIR:/tmp" <%= optional_tutorial_home_bind %> \
+SINGULARITYENV_LD_LIBRARY_PATH="$LD_LIBRARY_PATH" singularity run --contain -B "$TMPDIR:/tmp" <%= optional_tutorial_home_bind %> \
  "$RSTUDIO_SERVER_IMAGE" \
  --www-port "${port}" \
  --auth-none 0 \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -50,7 +50,7 @@ sed 's/^ \{2\}//' > "<%= working_dir_host %>/rsession.sh" << EOL
 
   exec &>>"\${RSESSION_LOG_FILE}"
 
-  source <%= session.staged_root.join('.env') %>
+  source "<%= working_dir_container %>/.env"
 
   # Launch the original command
   echo "Launching rsession..."
@@ -72,7 +72,7 @@ set -x
 echo "Starting up rserver..."
 
 # Dump environment without functions for use in rsession.sh, filtering readonly variables
-(set -o posix; set) | grep -vP '^(BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID)' > <%= session.staged_root.join('.env') %>
+(set -o posix; set) | grep -vP '^(BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID)' > "<%= working_dir_host %>/.env"
 
 # --contain is used to override the bindpaths specified in OSC's
 # singularity.conf which would otherwise conflict in /etc

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -50,6 +50,8 @@ sed 's/^ \{2\}//' > "<%= working_dir_host %>/rsession.sh" << EOL
 
   exec &>>"\${RSESSION_LOG_FILE}"
 
+  source <%= session.staged_root.join('.env') %>
+
   # Launch the original command
   echo "Launching rsession..."
   set -x
@@ -68,6 +70,9 @@ hostname
 set -x
 # Launch the RStudio Server
 echo "Starting up rserver..."
+
+# Dump environment without functions for use in rsession.sh, filtering readonly variables
+(set -o posix; set) | grep -vP '^(BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID)' > <%= session.staged_root.join('.env') %>
 
 # --contain is used to override the bindpaths specified in OSC's
 # singularity.conf which would otherwise conflict in /etc


### PR DESCRIPTION
In the next environment for Owens RStudio stopped working. This is the result of the environment not being properly exported to the rsession wrapper.