### PR TITLE
add texlive (LaTeX) module for saving pdf mardown files

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -28,6 +28,7 @@ setup_env () {
 
   module use /usr/local/share/lmodfiles/project/ondemand
   module load xalt/latest <%= context.version %> rstudio_container/2019Feb
+  module load texlive
   <%- if context.include_tutorials == "1" %>
   export R_LIBS_USER="<%= working_dir_container %>/Rworkshop"
   mkdir -p "<%= working_dir_host %>/Rworkshop"


### PR DESCRIPTION
Adding the texlive (texlive/2018) module to load so that users can create and save Markdown files. I verified that it works, and will add an image of it not working shortly.