### PR TITLE
Always push packages to CI repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,15 +20,18 @@ rpm-build:
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
 
 
-rpm-deploy:
-  variables:
-    RLS_SCRIPT: "./tmp/ondemand-packaging/release.py"
-    RLS_KEY: "/systems/osc_certs/ssh/ondemand-packaging/id_rsa"
-    RLS_OUTPUT: "./tmp/output/*"
-    SECTION: "main"
+rpm-deploy-ci:
   stage: deploy
   only:
     - tags
   script:
-    - if [[ "$CI_COMMIT_TAG" =~ .*_.* ]]; then export SECTION=ci; fi
-    - $RLS_SCRIPT --debug --pkey $RLS_KEY -c $SECTION $RLS_OUTPUT
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c ci ./tmp/output/*
+rpm-deploy:
+  stage: deploy
+  only:
+    - tags
+  except:
+    variables:
+      - $CI_COMMIT_TAG =~ /.*_.*/
+  script:
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*


### PR DESCRIPTION
This is identical to changes we made for main ondemand repo. Without this changes we will get lots of puppet errors in dev when packages exist in latest but not ci.