### PR TITLE
add the ability to choose GPU nodes, but only for version 3.6.3

### DIFF
--- a/form.js
+++ b/form.js
@@ -59,12 +59,14 @@ function set_node_type_change_handler() {
  */
 function set_version_change_hander() {
   let version_select = $("#batch_connect_session_context_version");
-  version_select.change(toggle_tutorial_control_visibility);
-
+  version_select.change(function(event){
+    toggle_tutorial_control_visibility(event);
+    toggle_gpu_nodes(event);
+  });
 }
 
 /**
- * Toggle the visibility of the tutorial
+ * Toggle the visibility of the tutorial for specific versions of R
  * @param  {Object} event The change event
  */
 function toggle_tutorial_control_visibility(event) {
@@ -75,6 +77,24 @@ function toggle_tutorial_control_visibility(event) {
   // Ensure unchecked if control is hidden
   if ( ! show ) {
     $(selector).prop('checked', false);
+  }
+}
+
+/**
+ * Given a change event from choosing a different verion of R, toggle 
+ * the ability to choose GPUs depending on the version.
+ * 
+ * @param  {Object} event The change event
+ */
+function toggle_gpu_nodes(event){
+  const show = /3\.6\.3/.test(event.target.value); // test seems more readable than = !! match
+  const gpu = $("#batch_connect_session_context_node_type option[value='gpu']");
+
+  if(show) {
+    gpu.show();
+  }else {
+    gpu.hide();
+    gpu.prop('selected', false);
   }
 }
 

--- a/form.yml
+++ b/form.yml
@@ -37,7 +37,7 @@ attributes:
         8AM - 6PM, Monday - Friday. There are 6 of these nodes on Owens.
       - **gpu** - (*1-28 cores*) Use an Owens node that has an [NVIDIA Tesla P100
         GPU] and loads the appropriate [CUDA] module(s). There are 160 of these nodes
-        on Owens. GPU Nodes are only available for R version 3.6.3.
+        on Owens. GPU nodes are only available for R version 3.6.3.
     options:
       - [ "any",     "any"     ]
       - [ "hugemem", "hugemem" ]

--- a/form.yml
+++ b/form.yml
@@ -35,10 +35,14 @@ attributes:
       - **debug** - (*1-28 cores*) For short sessions (= 1 hour) the debug
         queue will have the shortest wait time. This is only accessible during
         8AM - 6PM, Monday - Friday. There are 6 of these nodes on Owens.
+      - **gpu** - (*1-28 cores*) Use an Owens node that has an [NVIDIA Tesla P100
+        GPU] and loads the appropriate [CUDA] module(s). There are 160 of these nodes
+        on Owens. GPU Nodes are only available for R version 3.6.3.
     options:
       - [ "any",     "any"     ]
       - [ "hugemem", "hugemem" ]
       - [ "debug",   "debug"   ]
+      - [ "gpu",     "gpu"     ]
   version:
     widget: select
     label: "R version"


### PR DESCRIPTION
The new `app_rstudio_server/3.6.3` loads CUDA modules, so this PR allows users to choose GPU nodes, if that version is selected.


```
module show app_rstudio_server/3.6.3
...
depends_on("gnu/9.1.0","mkl/2019.0.3","rstudio/1.2.5001","R/.3.6.3","texlive","cuda/10.1.168")
```