### PR TITLE
specify TZ to get rid of warnings

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -63,6 +63,7 @@ sed 's/^ \{2\}//' > "$WORKING_DIR/rsession.sh" << EOL
   # rsession.sh doesn't share the same env as the outside script, so these
   # need to be set explicitly
   export R_LIBS_SITE="${R_LIBS_SITE}"
+  export TZ="US/Eastern"
 
   # Launch the original command
   echo "Launching rsession..."


### PR DESCRIPTION
Specify the TZ to get rid of warnings like this below because we're mounting `/etc/localtime` directly.

```
> Sys.timezone()
Failed to create bus connection: No such file or directory
Warning: Your system is mis-configured: ‘/etc/localtime’ is not a symlink
Warning: It is strongly recommended to set envionment variable TZ to ‘America/New_York’ (or equivalent)
```