### PR TITLE
use centos7 img and force home=sing_home

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -19,7 +19,7 @@ setup_env () {
   # the host into the guest, and so those values may vary between sites.
 
   module load ondemand
-  module load xalt/latest rstudio_launcher/0.1 <%= context.version %>
+  module load xalt/latest rstudio_launcher/centos7 <%= context.version %>
   <%- if context.include_tutorials == "1" %>
   export R_LIBS_USER="<%= tutorial_dir %>/Rworkshop"
   mkdir -p "<%= tutorial_dir %>/Rworkshop"
@@ -64,6 +64,7 @@ sed 's/^ \{2\}//' > "$WORKING_DIR/rsession.sh" << EOL
   # need to be set explicitly
   export R_LIBS_SITE="${R_LIBS_SITE}"
   export TZ="US/Eastern"
+  export HOME="$SINGULARITY_HOME"
 
   # Launch the original command
   echo "Launching rsession..."


### PR DESCRIPTION
there is some issue in binding all of etc /etc (which this image does)
and so we dropped it. only we need all of /etc so this re-enables it.
the isse is fixed if we set HOME=SINGULARITY_HOME so users in tutorials
and classes can create a ~/.rstudio directory (which before wouldn't work
because HOME was still being evaluated as the actual home which didn't
exist in the container).