### PR TITLE
Add pitzer exp

### DIFF
--- a/form.js
+++ b/form.js
@@ -17,16 +17,34 @@ function clamp(min, max, val) {
  */
 function current_cluster_capitalized(){
   var cluster = $('#batch_connect_session_context_cluster').val();
-  return capitalize(cluster);
+  return capitalize_words(cluster);
 }
 
 /**
- * Capitalize a string.
+ * Capitalize the words in a string and remove and '-'.  In the simplest case
+ * it simple capitalizes.  It assumes 'words' are hyphenated.
  *
- * @param      {string}  str     The string to capitalize
+ * @param      {string}  str     The word string to capitalize
+ *
+ * @example  given 'foo' this returns 'Foo'
+ * @example  given 'foo-bar' this returns 'FooBar'
  */
-function capitalize(str) {
-  return str ? str.charAt(0).toUpperCase() + str.slice(1) : "";
+function capitalize_words(str) {
+  var camel_case = "";
+  var capitalize = true;
+
+  str.split('').forEach((c) => {
+    if (capitalize) {
+      camel_case += c.toUpperCase();
+      capitalize = false;
+    } else if(c == '-') {
+      capitalize = true;
+    } else {
+      camel_case += c;
+    }
+  });
+
+  return camel_case;
 }
 
 /**
@@ -144,6 +162,7 @@ function set_cluster_change_handler() {
   cluster_input.change((event) => {
     fix_num_cores(event);
     toggle_options("batch_connect_session_context_version");
+    toggle_options("batch_connect_session_context_node_type");
   });
 }
 
@@ -172,7 +191,7 @@ function submit_blank_cores() {
  */
 function max_cores_for_cluster(cluster_name) {
   if(cluster_name.charAt(0).toUpperCase != cluster_name.charAt(0)){
-    cluster_name = capitalize(cluster_name);
+    cluster_name = capitalize_words(cluster_name);
   }
 
   const node_type_input = $('#batch_connect_session_context_node_type');
@@ -257,11 +276,12 @@ function toggle_visibility_of_form_group(form_id, show) {
 
 // Set the max value to be what was set in the last session
 fix_num_cores({ target: document.querySelector('#batch_connect_session_node_type') });
-toggle_options("batch_connect_session_context_version");
 toggle_tutorial_control_visibility(
   // Fake the event
   { target: document.querySelector('#batch_connect_session_context_version') }
 );
+toggle_options("batch_connect_session_context_version");
+toggle_options("batch_connect_session_context_node_type");
 
 // install handlers
 set_node_type_change_handler();

--- a/form.yml
+++ b/form.yml
@@ -14,6 +14,7 @@ attributes:
     options:
       - "owens"
       - "pitzer"
+      - "pitzer-exp"
   num_cores:
     widget: "number_field"
     label: "Number of cores"
@@ -21,7 +22,7 @@ attributes:
     help: |
       Number of cores on node type (4 GB per core unless requesting whole
       node). Leave blank if requesting full node.
-    min: 0
+    min: 1
     max: 28
     step: 1
   bc_account:
@@ -37,9 +38,12 @@ attributes:
       - **gpu** - Use a node that has a GPU and loads the requested [CUDA] module.
         - Owens has 160 of these nodes with a [NVIDIA Tesla P100 GPU].
         - Pitzer has 32 of these nodes with two [NVIDIA Tensor Core V100 GPU]s.
+        - Pitzer Expansion has 42 of these nodes with two [NVIDIA Tensor Core V100 GPU]s.
       - **hugemem** - Use a node that has a large amounts of RAM cores.
         - Owens has 16 of these nodes with 1.5TB of RAM and 40 cores.
         - Pitzer has 4 of these nodes with 3TB of RAM and 80 cores.
+      - **largemem** - Use a node that has a semi-large amounts of RAM cores.
+        - Pitzer Expansion has 12 of these nodes with 768GB of RAM and 80 cores.
       - **debug** - For short sessions (= 1 hour) the debug queueq
         will have the shortest wait time. This is only accessible during 8AM -
         6PM, Monday - Friday. There are 6 of these nodes on both Owens and pitzer.
@@ -53,28 +57,54 @@ attributes:
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
           data-min-ppn-pitzer: 1,
-          data-max-ppn-pitzer: 40
+          data-max-ppn-pitzer: 40,
+          data-min-ppn-pitzer-exp: 1,
+          data-max-ppn-pitzer-exp: 40,
+          data-option-for-owens: true,
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "hugemem", "hugemem",
           data-min-ppn-owens: 40,
           data-max-ppn-owens: 40,
           data-min-ppn-pitzer: 80,
-          data-max-ppn-pitzer: 80
+          data-max-ppn-pitzer: 80,
+          data-option-for-owens: true,
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: false
+        ]
+      - [
+          "largemem", "largemem",
+          data-min-ppn-pitzer-exp: 80,
+          data-max-ppn-pitzer-exp: 80,
+          data-option-for-owens: false,
+          data-option-for-pitzer: false,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "debug",   "debug",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
           data-min-ppn-pitzer: 0,
-          data-max-ppn-pitzer: 40
+          data-max-ppn-pitzer: 40,
+          data-min-ppn-pitzer: 1,
+          data-max-ppn-pitzer: 48,
+          data-option-for-owens: true,
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "gpu",     "gpu",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
           data-min-ppn-pitzer: 1,
-          data-max-ppn-pitzer: 40
+          data-max-ppn-pitzer: 40,
+          data-min-ppn-pitzer-exp: 1,
+          data-max-ppn-pitzer-exp: 40,
+          data-option-for-owens: true,
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
   version:
     widget: select
@@ -84,52 +114,62 @@ attributes:
       - [
           "4.0.2", "app_rstudio_server/4.0.2",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "3.6.3", "app_rstudio_server/3.6.3",
           data-option-for-owens: true,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "3.6.1", "gnu/9.1.0 mkl/2019.0.3 R/3.6.1 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-pitzer-exp: false
         ]
       - [
           "3.6.0", "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-pitzer-exp: false
         ]
       - [
           "3.6.0", "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.2.1335 texlive",
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "3.5.2", "intel/18.0.4 R/3.5.2 rstudio/1.1.456 texlive",
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "3.5.1", "intel/18.0.4 R/3.5.1 rstudio/1.1.456 texlive",
           data-option-for-owens: false,
-          data-option-for-pitzer: true
+          data-option-for-pitzer: true,
+          data-option-for-pitzer-exp: true
         ]
       - [
           "3.5.0", "intel/18.0.3 R/3.5.0 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-pitzer-exp: false
         ]
       - [
           "3.4.2", "intel/16.0.3 R/3.4.2 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-pitzer-exp: false
         ]
       - [
           "3.3.2", "intel/16.0.3 R/3.3.2 rstudio/1.0.136_server texlive",
           data-option-for-owens: true,
-          data-option-for-pitzer: false
+          data-option-for-pitzer: false,
+          data-option-for-pitzer-exp: false
         ]
   include_tutorials:
     widget: "check_box"

--- a/form.yml
+++ b/form.yml
@@ -42,8 +42,6 @@ attributes:
       - **hugemem** - Use a node that has a large amounts of RAM cores.
         - Owens has 16 of these nodes with 1.5TB of RAM and 40 cores.
         - Pitzer has 4 of these nodes with 3TB of RAM and 80 cores.
-      - **largemem** - Use a node that has a semi-large amounts of RAM cores.
-        - Pitzer Expansion has 12 of these nodes with 768GB of RAM and 80 cores.
       - **debug** - For short sessions (= 1 hour) the debug queueq
         will have the shortest wait time. This is only accessible during 8AM -
         6PM, Monday - Friday. There are 6 of these nodes on both Owens and pitzer.
@@ -59,7 +57,7 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-min-ppn-pitzer-exp: 1,
-          data-max-ppn-pitzer-exp: 40,
+          data-max-ppn-pitzer-exp: 48,
           data-option-for-owens: true,
           data-option-for-pitzer: true,
           data-option-for-pitzer-exp: true
@@ -73,14 +71,6 @@ attributes:
           data-option-for-owens: true,
           data-option-for-pitzer: true,
           data-option-for-pitzer-exp: false
-        ]
-      - [
-          "largemem", "largemem",
-          data-min-ppn-pitzer-exp: 80,
-          data-max-ppn-pitzer-exp: 80,
-          data-option-for-owens: false,
-          data-option-for-pitzer: false,
-          data-option-for-pitzer-exp: true
         ]
       - [
           "debug",   "debug",
@@ -101,7 +91,7 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-min-ppn-pitzer-exp: 1,
-          data-max-ppn-pitzer-exp: 40,
+          data-max-ppn-pitzer-exp: 48,
           data-option-for-owens: true,
           data-option-for-pitzer: true,
           data-option-for-pitzer-exp: true

--- a/form.yml
+++ b/form.yml
@@ -1,8 +1,6 @@
 ---
-cluster:
-  - "owens"
-  - "pitzer"
 form:
+  - cluster
   - version
   - bc_account
   - bc_num_hours
@@ -11,6 +9,11 @@ form:
   - include_tutorials
   - bc_email_on_started
 attributes:
+  cluster:
+    widget: "select"
+    options:
+      - "owens"
+      - "pitzer"
   num_cores:
     widget: "number_field"
     label: "Number of cores"

--- a/form.yml
+++ b/form.yml
@@ -86,7 +86,7 @@ attributes:
           "debug",   "debug",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
-          data-min-ppn-pitzer: 0,
+          data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,6 +1,25 @@
 <%-
-  ppn   = num_cores.to_i
-  props = node_type == "gpu" ? ":ppn=#{ppn}:gpus=1" : ":ppn=#{ppn}"
+  ppn             = num_cores.to_i
+  base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "#{ppn}"]
+
+  slurm_args = case node_type
+              when "gpu"
+                base_slurm_args += ["--gpus-per-node", "1"]
+              when "largemem"
+                base_slurm_args += ["--mem", "740G"]
+              else
+                base_slurm_args
+              end
+
+  torque_args = case node_type
+              when "gpu"
+                ":ppn=#{ppn}:gpus=1"
+              when "hugemem"
+                ppn == 80 ? ":ppn=#{ppn},mem=2989GB" : ":ppn=#{ppn}"
+              else
+                ":ppn=#{ppn}"
+              end
+
 -%>
 ---
 batch_connect:
@@ -10,5 +29,11 @@ script:
   queue_name: "debug"
   <%- end -%>
   native:
+    <%- unless cluster == 'pitzer-exp' %>
     resources:
-      nodes: "1<%= props %>"
+      nodes: "1<%= torque_args %>"
+    <%- else %>
+    <%- slurm_args.each do |arg| %>
+    - "<%= arg %>"
+    <%- end %>
+    <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -5,8 +5,6 @@
   slurm_args = case node_type
               when "gpu"
                 base_slurm_args += ["--gpus-per-node", "1"]
-              when "largemem"
-                base_slurm_args += ["--mem", "740G"]
               else
                 base_slurm_args
               end


### PR DESCRIPTION
add pitzer expansion
    
- change capitalize function to capitalize_words to change 'pitzer-exp'
  to PitzerExp (to access the data attributes)
- add option-for attributes to the node types because hugemem is not
  available on pitzer-exp and largemem is _only_ available on pitzer-exp
- lastly obviously, submit.yml.erb has to change to accomidate slurm
  options and torque options.

Again, borrowed heavily work done in jupyter: https://github.com/OSC/bc_osc_jupyter/pull/48