### PR TITLE
add owens-slurm cluster to begin migrating owens to Slurm

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -13,6 +13,7 @@ attributes:
     widget: "select"
     options:
       - "owens"
+      - "owens-slurm"
       - "pitzer"
   num_cores:
     widget: "number_field"
@@ -54,9 +55,12 @@ attributes:
           "any",     "any",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
+          data-min-ppn-owens-slurm: 1,
+          data-max-ppn-owens-slurm: 28,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
@@ -64,6 +68,7 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
@@ -71,15 +76,19 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "any gpu",     "gpu",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
+          data-min-ppn-owens-slurm: 1,
+          data-max-ppn-owens-slurm: 28,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
@@ -87,6 +96,7 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 40,
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
@@ -94,15 +104,19 @@ attributes:
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "hugemem", "hugemem",
           data-min-ppn-owens: 48,
           data-max-ppn-owens: 48,
+          data-min-ppn-owens-slurm: 48,
+          data-max-ppn-owens-slurm: 48,
           data-min-ppn-pitzer: 80,
           data-max-ppn-pitzer: 80,
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
@@ -110,15 +124,19 @@ attributes:
           data-min-ppn-pitzer: 48,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "debug",   "debug",
           data-min-ppn-owens: 1,
           data-max-ppn-owens: 28,
+          data-min-ppn-owens-slurm: 1,
+          data-max-ppn-owens-slurm: 28,
           data-min-ppn-pitzer: 1,
           data-max-ppn-pitzer: 48,
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
   version:
@@ -129,51 +147,61 @@ attributes:
       - [
           "4.0.2", "app_rstudio_server/4.0.2",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
           "3.6.3", "app_rstudio_server/3.6.3",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: true
         ]
       - [
           "3.6.1", "gnu/9.1.0 mkl/2019.0.3 R/3.6.1 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
       - [
           "3.6.0", "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
       - [
           "3.6.0", "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.2.1335 texlive",
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "3.5.2", "intel/18.0.4 R/3.5.2 rstudio/1.1.456 texlive",
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "3.5.1", "intel/18.0.4 R/3.5.1 rstudio/1.1.456 texlive",
           data-option-for-owens: false,
+          data-option-for-owens-slurm: false,
           data-option-for-pitzer: true
         ]
       - [
           "3.5.0", "intel/18.0.3 R/3.5.0 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
       - [
           "3.4.2", "intel/16.0.3 R/3.4.2 rstudio/1.1.380_server texlive",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
       - [
           "3.3.2", "intel/16.0.3 R/3.3.2 rstudio/1.0.136_server texlive",
           data-option-for-owens: true,
+          data-option-for-owens-slurm: true,
           data-option-for-pitzer: false
         ]
   include_tutorials:

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -29,8 +29,7 @@
               when "largemem"
                 base_slurm_args += ["--partition", "largemem", "--exclusive"]
               when "debug"
-                # partition handled in the script.queue_name below. Need to change when Owens switches to Slurm
-                base_slurm_args += ["--exclusive"]
+                base_slurm_args += ["--partition", "debug", "--exclusive"]
               else
                 base_slurm_args
               end
@@ -45,16 +44,19 @@
                 ":ppn=#{cores}"
               end
 
+  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
+
 -%>
 ---
 batch_connect:
   template: "basic"
 script:
-  <%- if node_type == "debug" -%>
+  # need to unify --partition args above and queue_name below when owens is fully Slurm
+  <%- if node_type == "debug" && torque_cluster -%>
   queue_name: "debug"
   <%- end -%>
   native:
-    <%- if cluster == 'owens' %>
+    <%- if torque_cluster %>
     resources:
       nodes: "1<%= torque_args %>"
     <%- else %>


### PR DESCRIPTION
add owens-slurm cluster to begin migrating owens to Slurm. With this addition we determine native arguments based on the `cluster.job.adapter` so this will work when migrated fully to Slurm and owens-slurm turns into just owens. 