### PR TITLE
remove owens-slurm cluster and torque related configs

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,6 +1,8 @@
 ---
+cluster:
+  - "owens"
+  - "pitzer"
 form:
-  - cluster
   - version
   - bc_account
   - bc_num_hours
@@ -9,12 +11,6 @@ form:
   - include_tutorials
   - bc_email_on_started
 attributes:
-  cluster:
-    widget: "select"
-    options:
-      - "owens"
-      - "owens-slurm"
-      - "pitzer"
   num_cores:
     widget: "number_field"
     label: "Number of cores"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -34,33 +34,12 @@
                 base_slurm_args
               end
 
-  torque_args = case node_type
-              when "gpu"
-                ":ppn=#{cores}:gpus=1"
-              when "hugemem"
-                # disregard what num_cores was submitted (0 or 48 are the only valid options)
-                ":ppn=48"
-              else
-                ":ppn=#{cores}"
-              end
-
-  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
-
 -%>
 ---
 batch_connect:
   template: "basic"
 script:
-  # need to unify --partition args above and queue_name below when owens is fully Slurm
-  <%- if node_type == "debug" && torque_cluster -%>
-  queue_name: "debug"
-  <%- end -%>
   native:
-    <%- if torque_cluster %>
-    resources:
-      nodes: "1<%= torque_args %>"
-    <%- else %>
     <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
-    <%- end %>
     <%- end %>


### PR DESCRIPTION
I noticed this while working on lmod stuff, that we still have `owens-slurm` as an option in the form. This removes that and removes all the torque related stuff in the submit.yml.erb.