### PR TITLE
enable loading modules in r-studio with instructions

### DIFF
--- a/info.md.erb
+++ b/info.md.erb
@@ -1,0 +1,19 @@
+### Importing modules with R
+**Import module function**
+
+```
+source(file.path(Sys.getenv("LMOD_PKG"), "init/R"))
+```
+
+**Load system module**
+
+```
+module("load", "blast")
+```
+
+**Load custom module**
+
+```
+module("use", "~/local/share/lmodfiles")
+module("load", "MyModuleA")
+```

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -65,6 +65,9 @@ sed 's/^ \{2\}//' > "$WORKING_DIR/rsession.sh" << EOL
   export R_LIBS_SITE="${R_LIBS_SITE}"
   export TZ="US/Eastern"
   export HOME="$SINGULARITY_HOME"
+  export MODULEPATH_ROOT="$MODULEPATH_ROOT"
+  export MODULEPATH="$MODULEPATH"
+  export LMOD_PKG="$LMOD_PKG"
 
   # Launch the original command
   echo "Launching rsession..."


### PR DESCRIPTION
Mutually exclusive with #53  this allows users to `module load` from within the Rstudio server's terminal windows.