### PR TITLE
rsync class materials if the env variable exists

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -38,6 +38,13 @@ if [[ "$SINGULARITY_HOME" != "$HOME" ]]; then
   touch "$SINGULARITY_HOME/0_${OSC_CLASS_ID:-osc_class}.md"
 
   export WORKING_DIR="<%= tutorial_dir %>"
+
+  # Copy over classroom materials if the env variable exists
+  if [[ -n "$OSC_CLASS_FILES" ]]; then
+    set -x
+    rsync -avz --ignore-existing "$OSC_CLASS_FILES" "$SINGULARITY_HOME"
+    { set +x; } 2>/dev/null
+  fi
 else
   export WORKING_DIR="<%= session_dir %>"
 fi


### PR DESCRIPTION
rsync class materials if the env variable exists because to help the ease of use for some classrooms & students that are not technically saavy enough to copy the materials themselves.