### PR TITLE
Ensure core count behavior works with Kubernetes

### DIFF
--- a/form.js
+++ b/form.js
@@ -170,9 +170,9 @@ function set_version_change_handler() {
 function set_cluster_change_handler() {
   const cluster_input = $('#batch_connect_session_context_cluster');
   cluster_input.change((event) => {
-    fix_num_cores(event);
     toggle_options("batch_connect_session_context_node_type");
     toggle_options("batch_connect_session_context_version");
+    fix_num_cores(event);
     toggle_email_on_started(event.target.value);
   });
 }

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -159,6 +159,12 @@ attributes:
         ]
       - [
           "pitzer",   "pitzer",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,
@@ -167,6 +173,12 @@ attributes:
         ]
       - [
           "owens",   "owens",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,
@@ -175,6 +187,12 @@ attributes:
         ]
       - [
           "pitzer gpu",   "pitzer-gpu",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,
@@ -183,6 +201,12 @@ attributes:
         ]
       - [
           "owens gpu",   "owens-gpu",
+          data-min-ppn-kubernetes: 1,
+          data-max-ppn-kubernetes: 10,
+          data-min-ppn-kubernetes-test: 1,
+          data-max-ppn-kubernetes-test: 10,
+          data-min-ppn-kubernetes-dev: 1,
+          data-max-ppn-kubernetes-dev: 6,
           data-option-for-owens: false,
           data-option-for-pitzer: false,
           data-option-for-kubernetes: true,


### PR DESCRIPTION
Fixes #65

Because I removed logic to look at cluster + node type, we either have to do the lowest possible cluster (owens) or just set on some low value. I opted to just max out core count for Kubernetes at 10, but can easily adjust to max the max the max for smallest nodes which are Owens.