### PR TITLE
classrooms only bind the directories they have access to

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -53,6 +53,21 @@ else
   export WORKING_DIR="<%= session_dir %>"
 fi
 
+# sanatize SINGULARITY_BINDPATH for mounts that don't exist or that you
+# have no access to.
+set -x
+if [[ "${SINGULARITY_BINDPATH:-x}" != "x" ]]; then
+
+  SAFE_BINDPATH=""
+  IFS=',' read -r -a array <<< "$SINGULARITY_BINDPATH"
+  for dir in "${array[@]}"; do
+    [ -d "$dir" ] && SAFE_BINDPATH="$dir,$SAFE_BINDPATH"
+  done
+
+  export SINGULARITY_BINDPATH=$(echo $SAFE_BINDPATH | sed 's/,$//')
+fi
+set +x
+
 #
 # Start RStudio Server
 #


### PR DESCRIPTION
classrooms should only bind the directories they have access to.  This means classrooms can work out of the box, while PIs create the directories in the project space after the fact.