### PR TITLE
Avoid errors for class.osc.edu

### DIFF
--- a/form.js
+++ b/form.js
@@ -138,12 +138,9 @@ function toggle_options(element_name) {
 /**
  * Toggle the visibility of the email on started field
  */
-function toggle_email_on_started(selected_cluster) {
-  if(selected_cluster === undefined) {
-    return;
-  }
+function toggle_email_on_started() {
   const element = $('#batch_connect_session_context_bc_email_on_started');
-  const supported = !selected_cluster.includes('kubernetes');
+  const supported = !current_cluster_capitalized().includes('Kubernetes');
 
   toggle_visibility_of_form_group(element, supported);
 }
@@ -176,7 +173,7 @@ function set_cluster_change_handler() {
     toggle_options("batch_connect_session_context_node_type");
     toggle_options("batch_connect_session_context_version");
     fix_num_cores(event);
-    toggle_email_on_started(event.target.value);
+    toggle_email_on_started();
   });
 }
 
@@ -277,9 +274,7 @@ toggle_tutorial_control_visibility(
   // Fake the event
   { target: document.querySelector('#batch_connect_session_context_version') }
 );
-toggle_email_on_started(
-  $('#batch_connect_session_context_cluster option:selected').val()
-);
+toggle_email_on_started();
 toggle_options("batch_connect_session_context_version");
 toggle_options("batch_connect_session_context_node_type");
 

--- a/form.js
+++ b/form.js
@@ -139,6 +139,9 @@ function toggle_options(element_name) {
  * Toggle the visibility of the email on started field
  */
 function toggle_email_on_started(selected_cluster) {
+  if(selected_cluster === undefined) {
+    return;
+  }
   const element = $('#batch_connect_session_context_bc_email_on_started');
   const supported = !selected_cluster.includes('kubernetes');
 


### PR DESCRIPTION
I saw this in javascript console when using `local` directory forms like for class.osc.edu:

```
new:695 Uncaught TypeError: Cannot read property 'includes' of undefined
    at toggle_email_on_started (new:695)
    at new:829
    at new:840
```