### PR TITLE
Adjust memory ratio for K8 jobs

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -49,10 +49,12 @@ script:
    if node_type =~ /owens/
      compute_cluster = "owens"
      apps_path = "/usr/local"
+     # Memory per core with hyperthreading enabled
      memory_mb = num_cores.to_i * 2200
    elsif node_type =~ /pitzer/
      compute_cluster = "pitzer"
      apps_path = "/apps"
+     # Memory per core with hyperthreading enabled
      memory_mb = num_cores.to_i * 4000
    end
    mounts = {

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -49,9 +49,11 @@ script:
    if node_type =~ /owens/
      compute_cluster = "owens"
      apps_path = "/usr/local"
+     memory_mb = num_cores.to_i * 2200
    elsif node_type =~ /pitzer/
      compute_cluster = "pitzer"
      apps_path = "/apps"
+     memory_mb = num_cores.to_i * 4000
    end
    mounts = {
      'home'    => OodSupport::User.new.home,
@@ -80,7 +82,7 @@ script:
         KUBECONFIG: "/dev/null"
       port: "8080"
       cpu: "<%= num_cores %>"
-      memory: "<%= num_cores.to_i * 4 %>Gi"
+      memory: "<%= memory_mb %>Mi"
     mounts:
     <%- mounts.each_pair do |name, mount| -%>
       - type: host


### PR DESCRIPTION
This is the new memory ratio with hyperthreading enabled.  This is rounded down slightly:

```
# kubectl get node -l kubernetes-worker -o=custom-columns=NAME:.metadata.name,CLUSTER:.metadata.labels.'osc\.edu/cluster',CPU:.status.capacity.cpu,MEMORY:.status.capacity.memory
NAME           CLUSTER   CPU   MEMORY
kubeworker01   pitzer    96    394620128Ki
kubeworker02   pitzer    96    394620124Ki
kubeworker03   pitzer    96    394620120Ki
kubeworker04   owens     56    131761240Ki
kubeworker05   owens     56    131761240Ki
kubeworker06   owens     56    131761232Ki
kubeworker07   owens     56    131761232Ki

[root@kubecontroller ~]# echo "394620128 / 1024 / 96" | bc -l
4014.28352864583333333333
[root@kubecontroller ~]# echo "131761232 / 1024 / 56" | bc -l
2297.73353794642857142857
```

