### PR TITLE
mount alternatives for binaries

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -144,6 +144,7 @@ SINGULARITYENV_LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
  -B /etc/fonts \
  -B /etc/profile \
  -B /etc/profile.d \
+ -B /etc/alternatives \
  -B <%= module_dir %> \
  "$RSTUDIO_SERVER_IMAGE" \
  --www-port "${port}" \


### PR DESCRIPTION
mount alternatives for binaries.  `ld` was not being found because `/usr/bin/ld` is actually a symlink to `/etc/alternatives/ld`. 

We ended up getting xalt errors like below.
```
XALT Error: unable to find ldcollect2: error: ld returned 1 exit status
```