### PR TITLE
Revert "rm c18 options"

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -73,6 +73,16 @@ attributes:
           data-option-for-cluster-kubernetes-dev: false
         ]
       - [
+          "40 core",     "any-40core",
+          data-min-num-cores-for-cluster-pitzer: 1,
+          data-max-num-cores-for-cluster-pitzer: 40,
+          data-option-for-cluster-owens: false,
+          data-option-for-cluster-ascend: false,
+          data-option-for-cluster-kubernetes: false,
+          data-option-for-cluster-kubernetes-test: false,
+          data-option-for-cluster-kubernetes-dev: false
+        ]
+      - [
           "48 core",     "any-48core",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 48,
@@ -90,6 +100,16 @@ attributes:
           data-max-num-cores-for-cluster-pitzer: 48,
           data-min-num-cores-for-cluster-ascend: 1,
           data-max-num-cores-for-cluster-ascend: 88,
+          data-option-for-cluster-kubernetes: false,
+          data-option-for-cluster-kubernetes-test: false,
+          data-option-for-cluster-kubernetes-dev: false
+        ]
+      - [
+          "40 core gpu",     "gpu-40core",
+          data-min-num-cores-for-cluster-pitzer: 1,
+          data-max-num-cores-for-cluster-pitzer: 40,
+          data-option-for-cluster-owens: false,
+          data-option-for-cluster-ascend: false,
           data-option-for-cluster-kubernetes: false,
           data-option-for-cluster-kubernetes-test: false,
           data-option-for-cluster-kubernetes-dev: false


### PR DESCRIPTION
Significant downtime for c18 has been pushed out a few months. Now that we need to make updates, it's time to revert this.

Reverts OSC/bc_osc_rstudio_server#110

