### PR TITLE
correct minimums on huge & largemem nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.25.2] - 2023-01-09
+
+- Use correct minimums for huge & large mem nodes in [114](https://github.com/OSC/bc_osc_rstudio_server/pull/114).
+
 ## [0.25.1] - 2023-01-09
 
 - Allow for partial nodes huge & large mem nodes in [113](https://github.com/OSC/bc_osc_rstudio_server/pull/113).
@@ -406,7 +410,8 @@ loads R_LIBS_SITE environment variable if it is set.
 ### Added
 - Initial release!
 
-[Unreleased]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.25.1...HEAD
+[Unreleased]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.25.2...HEAD
+[0.25.2]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/OSC/bc_osc_rstudio_server/compare/v0.24.0...v0.24.1

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -126,9 +126,9 @@ attributes:
         ]
       - [
           "hugemem", "hugemem",
-          data-min-num-cores-for-cluster-owens: 1,
+          data-min-num-cores-for-cluster-owens: 4,
           data-max-num-cores-for-cluster-owens: 48,
-          data-min-num-cores-for-cluster-pitzer: 1,
+          data-min-num-cores-for-cluster-pitzer: 20,
           data-max-num-cores-for-cluster-pitzer: 80,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-kubernetes: false,
@@ -137,7 +137,7 @@ attributes:
         ]
       - [
           "largemem", "largemem",
-          data-min-num-cores-for-cluster-pitzer: 1,
+          data-min-num-cores-for-cluster-pitzer: 24,
           data-max-num-cores-for-cluster-pitzer: 48,
           data-option-for-cluster-owens: false,
           data-option-for-cluster-ascend: false,


### PR DESCRIPTION
Use the correct minimums on huge & largemem nodes. I.e., 1 is not a valid minimum for these partitions.