### PR TITLE
fix nextgen ascend and rm ability to specify 0 cores

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,9 +1,8 @@
 ---
 cluster:
-  - "owens"
   - "pitzer"
   - "ascend"
-  - "ascend-nextgen"
+  - "ascend_nextgen"
   - "cardinal"
   - "kubernetes"
   - "kubernetes-test"
@@ -21,8 +20,8 @@ attributes:
     label: "Number of cores"
     value: 1
     help: |
-      Number of cores on node type (4 GB per core unless requesting whole
-      node). Leave blank if requesting full node.
+      The minimum and maximum will change based on your choice of Node type
+      and Cluster.
     min: 1
     max: 28
     step: 1
@@ -60,7 +59,7 @@ attributes:
           data-min-num-cores-for-cluster-ascend: 1,
           data-max-num-cores-for-cluster-ascend: 84,
           data-max-num-cores-for-cluster-ascend-nextgen: 1,
-          data-max-num-cores-for-cluster-ascend-nextgen: 84,
+          data-max-num-cores-for-cluster-ascend-nextgen: 118,
           data-min-num-cores-for-cluster-cardinal: 1,
           data-max-num-cores-for-cluster-cardinal: 96,
           data-option-for-cluster-kubernetes: false,
@@ -100,7 +99,7 @@ attributes:
           data-min-num-cores-for-cluster-ascend: 1,
           data-max-num-cores-for-cluster-ascend: 88,
           data-min-num-cores-for-cluster-ascend-nextgen: 1,
-          data-max-num-cores-for-cluster-ascend-nextgen: 88,
+          data-max-num-cores-for-cluster-ascend-nextgen: 118,
           data-min-num-cores-for-cluster-cardinal: 1,
           data-max-num-cores-for-cluster-cardinal: 96,
           data-option-for-cluster-kubernetes: false,

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,17 +1,6 @@
 <%-
-  cores = num_cores.to_i
 
-  if cores == 0 && cluster == "pitzer"
-    # little optimization for pitzer nodes. They want the whole node, if they chose 'any',
-    # it can be scheduled on p18 or p20 nodes. If not, they'll get the constraint below.
-    base_slurm_args = ["--nodes", "1", "--exclusive"]
-  elsif cores == 0
-    # full node on owens
-    cores = 28
-    base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "28"]
-  else
-    base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "#{cores}"]
-  end
+  base_slurm_args = ["--nodes", "1", "--ntasks-per-node", "#{num_cores.to_i}"]
 
   slurm_args = case node_type
               when "gpu-40core"


### PR DESCRIPTION
fix nextgen ascend and rm ability to specify 0 cores. I'm removing the ability to specify 0 cores and get the entire machine becauuse (a) it's become a bit too much to handle and (b) we now have a lot of dynamic ways of setting the min and max, so the help text can just reflect that.