### PR TITLE
Revert "updates for pitzer el9 migration"

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -214,6 +214,7 @@ attributes:
     options:
       - [
           "4.4.0", "gcc/12.3.0 R/4.4.0",
+          data-option-for-cluster-pitzer: false,
           data-option-for-cluster-kubernetes: false,
           data-option-for-cluster-kubernetes-test: false,
           data-option-for-cluster-kubernetes-dev: false,
@@ -222,7 +223,6 @@ attributes:
           "4.4.0", "rstudio/2022.07.2 R/4.4.0",
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer: false,
         ]
       - [
           "4.3.0", "rstudio/2022.07.2 R/4.3.0",

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -9,7 +9,7 @@
   r_version = match[2] unless match[2].nil?
 
   module_dir = context.cluster == 'owens' ? '/usr' : '/apps'
-  all_modules = if r_version >= '4.2' && ['owens', 'kubernetes', 'kubernetes-test', 'kubernetes-dev'].include?(context.cluster)
+  all_modules = if r_version >= '4.2' && ['owens', 'pitzer', 'kubernetes', 'kubernetes-test', 'kubernetes-dev'].include?(context.cluster)
                   "gnu/11.2.0 mkl/2021.3.0 #{context.version}"
                 else
                   context.version
@@ -21,6 +21,9 @@ setup_env () {
   module purge
 
   module load project/ondemand
+  <%- if context.cluster !~ /kubernetes|ascend|cardinal/ -%>
+  module load rstudio_launcher/centos7
+  <%- end -%>
   module load <%= all_modules %>
 }
 


### PR DESCRIPTION
Reverts OSC/bc_osc_rstudio_server#132

revert this because it's not the correct path forward for user testing.