### PR TITLE
merge pitzer-rhel9 into the pitzer cluster

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,7 +1,6 @@
 ---
 cluster:
   - "pitzer"
-  - "pitzer-rhel9"
   - "ascend"
   - "cardinal"
   - "kubernetes"
@@ -54,8 +53,6 @@ attributes:
           "any",     "any",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 48,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 48,
           data-min-num-cores-for-cluster-ascend: 1,
           data-max-num-cores-for-cluster-ascend: 118,
           data-min-num-cores-for-cluster-cardinal: 1,
@@ -68,8 +65,6 @@ attributes:
           "40 core",     "any-40core",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 40,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 40,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-kubernetes: false,
@@ -80,8 +75,6 @@ attributes:
           "48 core",     "any-48core",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 48,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 48,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-kubernetes: false,
@@ -92,8 +85,6 @@ attributes:
           "any gpu",     "gpu",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 48,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 48,
           data-min-num-cores-for-cluster-ascend: 1,
           data-max-num-cores-for-cluster-ascend: 118,
           data-min-num-cores-for-cluster-cardinal: 1,
@@ -106,8 +97,6 @@ attributes:
           "40 core gpu",     "gpu-40core",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 40,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 40,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-kubernetes: false,
@@ -118,8 +107,6 @@ attributes:
           "48 core gpu",     "gpu-48core",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 48,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 48,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-kubernetes: false,
@@ -130,8 +117,6 @@ attributes:
           "hugemem", "hugemem",
           data-min-num-cores-for-cluster-pitzer: 20,
           data-max-num-cores-for-cluster-pitzer: 80,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 20,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 80,
           data-min-num-cores-for-cluster-cardinal: 47,
           data-max-num-cores-for-cluster-cardinal: 96,
           data-option-for-cluster-ascend: false,
@@ -143,8 +128,6 @@ attributes:
           "largemem", "largemem",
           data-min-num-cores-for-cluster-pitzer: 24,
           data-max-num-cores-for-cluster-pitzer: 48,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 24,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 48,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-pitzer: true,
           data-option-for-cluster-cardinal: false,
@@ -156,8 +139,6 @@ attributes:
           "debug",   "debug",
           data-min-num-cores-for-cluster-pitzer: 1,
           data-max-num-cores-for-cluster-pitzer: 48,
-          data-min-num-cores-for-cluster-pitzer-rhel9: 1,
-          data-max-num-cores-for-cluster-pitzer-rhel9: 48,
           data-option-for-cluster-pitzer: true,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
@@ -174,7 +155,6 @@ attributes:
           data-min-num-cores-for-cluster-kubernetes-dev: 1,
           data-max-num-cores-for-cluster-kubernetes-dev: 6,
           data-option-for-cluster-pitzer: false,
-          data-option-for-cluster-pitzer-rhel9: false,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-kubernetes: true,
@@ -190,7 +170,6 @@ attributes:
           data-min-num-cores-for-cluster-kubernetes-dev: 1,
           data-max-num-cores-for-cluster-kubernetes-dev: 6,
           data-option-for-cluster-pitzer: false,
-          data-option-for-cluster-pitzer-rhel9: false,
           data-option-for-cluster-ascend: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-kubernetes: true,
@@ -204,91 +183,43 @@ attributes:
     options:
       - [
           "4.4.0", "gcc/12.3.0 R/4.4.0",
-          data-option-for-cluster-pitzer: false,
           data-option-for-cluster-kubernetes: false,
           data-option-for-cluster-kubernetes-test: false,
           data-option-for-cluster-kubernetes-dev: false,
         ]
       - [
           "4.4.0", "rstudio/2022.07.2 R/4.4.0",
+          data-option-for-cluster-pitzer: false,
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer-rhel9: false,
         ]
       - [
           "4.3.0", "rstudio/2022.07.2 R/4.3.0",
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer-rhel9: false,
+          data-option-for-cluster-pitzer: false,
         ]
       - [
           "4.2.1", "rstudio/2022.07.2 R/4.2.1",
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer-rhel9: false,
+          data-option-for-cluster-pitzer: false,
         ]
       - [
           "4.1.0", "app_rstudio_server/4.1.0",
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer-rhel9: false,
+          data-option-for-cluster-pitzer: false,
         ]
       - [
           "4.0.2", "app_rstudio_server/4.0.2",
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer-rhel9: false,
+          data-option-for-cluster-pitzer: false,
         ]
       - [
           "3.6.3", "app_rstudio_server/3.6.3",
           data-option-for-cluster-cardinal: false,
           data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer-rhel9: false,
-        ]
-      - [
-          "3.6.1", "gnu/9.1.0 mkl/2019.0.3 R/3.6.1 rstudio/1.1.380_server texlive",
-          data-option-for-cluster-ascend: false,
           data-option-for-cluster-pitzer: false,
-          data-option-for-cluster-pitzer-rhel9: false,
-          data-option-for-cluster-cardinal: false,
-          data-option-for-cluster-kubernetes: false,
-          data-option-for-cluster-kubernetes-test: false,
-          data-option-for-cluster-kubernetes-dev: false
-        ]
-      - [
-          "3.6.0", "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.2.1335 texlive",
-          data-option-for-cluster-ascend: false,
-          data-option-for-cluster-cardinal: false,
-          data-option-for-cluster-pitzer-rhel9: false,
-          data-option-for-cluster-kubernetes: false,
-          data-option-for-cluster-kubernetes-test: false,
-          data-option-for-cluster-kubernetes-dev: false
-        ]
-      - [
-          "3.5.2", "intel/18.0.4 R/3.5.2 rstudio/1.1.456 texlive",
-          data-option-for-cluster-ascend: false,
-          data-option-for-cluster-cardinal: false,
-          data-option-for-cluster-pitzer-rhel9: false,
-          data-option-for-cluster-kubernetes: false,
-          data-option-for-cluster-kubernetes-test: false,
-          data-option-for-cluster-kubernetes-dev: false
-        ]
-      - [
-          "3.5.1", "intel/18.0.4 R/3.5.1 rstudio/1.1.456 texlive",
-          data-option-for-cluster-ascend: false,
-          data-option-for-cluster-cardinal: false,
-          data-option-for-cluster-pitzer-rhel9: false,
-          data-option-for-cluster-kubernetes: false,
-          data-option-for-cluster-kubernetes-test: false,
-          data-option-for-cluster-kubernetes-dev: false
-        ]
-      - [
-          "3.5.0", "intel/18.0.3 R/3.5.0 rstudio/1.1.380_server texlive",
-          data-option-for-cluster-ascend: false,
-          data-option-for-cluster-pitzer: false,
-          data-option-for-cluster-pitzer-rhel9: false,
-          data-option-for-cluster-cardinal: false,
-          data-option-for-cluster-kubernetes: false,
-          data-option-for-cluster-kubernetes-test: false,
-          data-option-for-cluster-kubernetes-dev: false
         ]

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -8,7 +8,7 @@
   r_version = match[1] unless match[1].nil?
   r_version = match[2] unless match[2].nil?
 
-  all_modules = if r_version >= '4.2' && ['pitzer', 'kubernetes', 'kubernetes-test', 'kubernetes-dev'].include?(context.cluster)
+  all_modules = if r_version >= '4.2' && ['kubernetes', 'kubernetes-test', 'kubernetes-dev'].include?(context.cluster)
                   "gnu/11.2.0 mkl/2021.3.0 #{context.version}"
                 else
                   context.version


### PR DESCRIPTION
merge pitzer-rhel9 into the pitzer cluster. Lots of updates because pitzer (after the upgrade) isn't going to have any of these modules.